### PR TITLE
[코테반 4회차] seongwoo-review: 5427_불, 11559_PuyoPuyo 풀이, 2146_다리만들기 (미완)

### DIFF
--- a/코테반/4회차/11559_PuyoPuyo/bj_11559_PuyoPuyo_조성우.java
+++ b/코테반/4회차/11559_PuyoPuyo/bj_11559_PuyoPuyo_조성우.java
@@ -1,2 +1,157 @@
+/*
+< 내 풀이전략 >
+
+ 1. 바닥(Y-1)부터 돌면서 방문안한 뿌요(startPuyo) 를 찾는다. 
+ 2. bfs( startPuyo )로 4개이상으로 이뤄진 뿌요그룹을 찾아 반환받고, MatchedPuyos에 추가(addAll)한다.
+ 3. 1~2의 반복 끝에 찾아진, 즉 한 스텝에서 발생한 모든 유효한 뿌요그룹 내 뿌요들(MatchedPuyos)를 제거하고, 연쇄(result)++
+    -> 3-ESCAPE) 만일 MatchedPuyos.size()가 0인 경우, 즉 유효한 뿌요가 없는 경우 즉시 종료하고 결과를 출력한다.
+ 4. applyGravity()로 중력을 적용한다.
+ 5. 3-ESCAPE로 탈출할 때 까지 반복한다.
+
+ */
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+
 public class bj_11559_PuyoPuyo_조성우 {
+
+  static int result = 0;
+
+  static int Y = 12, X = 6;
+  static int[] dx = {0, 1, 0, -1};
+  static int[] dy = {-1, 0, 1, 0};
+
+  static char[][] board = new char[Y][X];
+  static boolean[][] visited = new boolean[Y][X];
+
+  static List<Point> MatchedPuyos = new ArrayList<>();
+
+  public static void main(String[] args) throws IOException {
+
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    //= start: 입력
+    for (int y = 0; y < Y; y++) {
+      String str = br.readLine();
+      for (int x = 0; x < X; x++) {
+        board[y][x] = str.charAt(x);
+      }
+    }
+    // end : 입력
+
+    //= start: 메인로직
+    while (true) {
+      for (int y = Y - 1; y >= 0; y--) {
+        boolean anyPuyoInThisRow = false;   // 한 행 내 아무런 뿌요도 없다면(false) 그 위는 볼필요도 없음
+
+        for (int x = 0; x < X; x++) {
+          //= start: if - 방문 안한 뿌요가 있다면 bfs() 고고
+          if (board[y][x] != '.') {
+              anyPuyoInThisRow = true;
+              if (!visited[y][x]) {
+                  Point startPuyo = new Point(x, y);
+                  List<Point> bfsResult = bfs(startPuyo); // bfs()
+
+                  MatchedPuyos.addAll( // bfs결과가 4개 이상의 뿌요그룹인 경우 제거대상 추가
+                          (bfsResult != null) ? bfsResult : new ArrayList<>());
+              }
+          } // end: if
+        } // end : for - x
+        
+        if (!anyPuyoInThisRow) { 
+          break;
+        }
+      } // end: for - y
+      
+      if (MatchedPuyos.size() == 0) {   // 종료조건: 매치된 뿌요그룹이 하나도 없다면 종료
+          break;
+      } 
+
+      //= start: 한스텝 내 매치된 모든 뿌요그룹 제거 & 재초기화
+      for (Point matchedPuyo : MatchedPuyos) {
+        board[matchedPuyo.y][matchedPuyo.x] = '.';
+      }
+      MatchedPuyos.clear();
+      visited = new boolean[Y][X];
+      result++;
+      // end: 뿌요그룹 제거
+
+      applyGravity(); // 중력처리
+    } // end: while
+    // end : 메인로직
+
+    System.out.println(result);
+  }
+
+  // BFS 메서드(startPuyo가 속한 뿌요그룹 탐색)
+  static List<Point> bfs(Point startPuyo) {
+    char color = board[startPuyo.y][startPuyo.x];
+    List<Point> groupedPuyos = new ArrayList<>();
+
+    Queue<Point> q = new ArrayDeque<>();
+    q.offer(startPuyo);
+    groupedPuyos.add(startPuyo);
+    visited[startPuyo.y][startPuyo.x] = true;
+
+    // start: while
+    while (!q.isEmpty()) {
+      Point cur = q.poll();
+
+      for (int dir = 0; dir < 4; dir++) {
+        int mvX = cur.x + dx[dir];
+        int mvY = cur.y + dy[dir];
+
+        if (mvX < 0 || mvY < 0 || mvX >= X || mvY >= Y || visited[mvY][mvX]) {
+          continue;
+        }
+        if (board[mvY][mvX] != color) {
+          continue;
+        }
+        Point newPuyo = new Point(mvX, mvY);
+
+        groupedPuyos.add(newPuyo);
+        q.offer(newPuyo);
+        visited[mvY][mvX] = true;
+      }
+    }
+    // end: while
+
+    //= bfs() 결과 반환
+    if (groupedPuyos.size() < 4) {
+      return null;
+    }
+    return groupedPuyos;
+  }
+
+  //=METHOD: 중력처리
+  static void applyGravity() {
+    for (int x = 0; x < X; x++) {
+      for (int y = Y - 2; y >= 0; y--) { // 바닥에서 두 번째 줄부터 시작
+        if (board[y][x] != '.') {
+          int fallToY = y;
+          while (fallToY + 1 < Y && board[fallToY + 1][x] == '.') {
+            fallToY++; // 빈 공간을 찾아서 한 칸씩 아래로
+          }
+          if (fallToY != y) {
+            board[fallToY][x] = board[y][x]; // 뿌요를 아래로 이동
+            board[y][x] = '.'; // 이동한 자리는 빈 공간으로 설정
+          }
+        }
+      }
+    }
+  }
+
+  static class Point {
+
+    int x, y;
+
+    public Point(int x, int y) {
+      this.x = x;
+      this.y = y;
+    }
+  }
 }

--- a/코테반/4회차/2146_다리만들기/bj_2146_다리만들기_조성우.java
+++ b/코테반/4회차/2146_다리만들기/bj_2146_다리만들기_조성우.java
@@ -1,2 +1,131 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
 public class bj_2146_다리만들기_조성우 {
+
+  static int[] dx = {0, 1, 0, -1};
+  static int[] dy = {-1, 0, 1, 0};
+  public static void main(String[] args) throws IOException {
+    int resultMinBridge = Integer.MAX_VALUE;
+
+    //= start : 입력
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    int N = Integer.parseInt(br.readLine());
+    List<List<Point>> islandList = new ArrayList<>();
+    boolean[][] board = new boolean[N][N];
+
+    for (int y = 0; y < N; y++){
+      StringTokenizer st = new StringTokenizer(br.readLine());
+      for (int x = 0; x < N; x++){
+        board[y][x] = (Integer.parseInt(st.nextToken()) == 1) ? true : false;
+      }
+    }
+    // end : 입력
+
+    //= start: BFS() 섬 그룹 모두 찾기
+    boolean[][] visited = new boolean[N][N];
+    for (int y = 0; y < N; y++){
+      for (int x = 0; x < N; x++){
+        if (visited[y][x] || !board[y][x] ){
+          continue;
+        }
+
+        Point start = new Point(x, y);
+
+        Queue<Point> q = new ArrayDeque<>();
+        List<Point> startIsland = new ArrayList<>();
+        q.offer(start);
+        startIsland.add(start);
+
+        visited[start.y][start.x] = true;
+
+        List<Point> island = bfs( q, startIsland, board, visited );
+        islandList.add(island);
+      }
+    }
+
+    //= start: 두 섬 사이 거리 비교 ( 모든 섬들에 대해, 최외곽 간 비교 )
+    for (int i = 0; i < islandList.size(); i++){
+      for (int j = i + 1; j < islandList.size(); j++){
+        List<Point> islandA = islandList.get(i);
+        List<Point> islandB = islandList.get(j);
+        resultMinBridge = Math.min(resultMinBridge, compareIslandBorders(islandA, islandB));
+      }
+    }
+
+    // end
+    System.out.println(resultMinBridge);
+  }
+
+  static int compareIslandBorders(List<Point> A, List<Point> B){
+    int minBridgeLen = Integer.MAX_VALUE;
+    for (Point a : A){
+      if (!a.isBorder){
+        continue;
+      }
+      for (Point b : B){
+        if (!b.isBorder){
+          continue;
+        }
+        minBridgeLen = Math.min(minBridgeLen, calcBridgeLength(a, b));
+      }
+    }
+    return minBridgeLen;
+  }
+
+  static int calcBridgeLength(Point A, Point B){
+    return Math.abs(A.x  - B.x) + Math.abs(A.y - B.y) - 1;
+  }
+  static List<Point> bfs ( Queue<Point> q, List<Point> island, boolean[][] board, boolean[][] visited ){
+    while(!q.isEmpty()){
+      Point cur = q.poll();
+
+      boolean[][] addedBorder = new boolean[board.length][board.length];
+      for (int dir = 0; dir < 4; dir++){
+        int mvX = cur.x + dx[dir];
+        int mvY = cur.y + dy[dir];
+
+        if ( mvY < 0 || mvX < 0 || mvX >= board.length || mvY >= board.length ){
+          continue;
+        }
+        if (visited[mvY][mvX]){
+          continue;
+        }
+        if ( !board[mvY][mvX] ){ // mv가 바다라는건 cur이 바다랑 인접했다는 뜻이므로, cur의 isBorder를 true로 바꿔줌
+          if (addedBorder[cur.y][cur.x]){
+            continue;
+          }
+          addedBorder[cur.y][cur.x] = true;
+          island.get(island.indexOf(cur)).isBorder = true;
+          continue;
+        }
+
+        visited[mvY][mvX] = true;
+        Point newPoint = new Point(mvX, mvY);
+        q.offer(newPoint);
+        island.add(newPoint);
+      }
+    }
+    return island;
+  }
+  static class Point{
+    int x, y;
+    boolean isBorder;
+
+    public Point(int x, int y){
+      this.x = x;
+      this.y = y;
+    }
+    public Point(int x, int y, boolean isBorder){
+      this.x = x;
+      this.y = y;
+      this.isBorder = isBorder;
+    }
+  }
 }

--- a/코테반/4회차/5427_불/bj_5427_불_조성우.java
+++ b/코테반/4회차/5427_불/bj_5427_불_조성우.java
@@ -1,0 +1,128 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class bj_5427_불_조성우 {
+  static int[] dx = {0, 1, 0, -1};
+  static int[] dy = {-1, 0, 1, 0};
+  static Queue<Point> q = new ArrayDeque<>();
+  static Queue<Point> qFire = new ArrayDeque<>();
+  static char[][] board;
+  static boolean[][] visited;
+  static int W, H;
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    int T = Integer.parseInt(br.readLine());
+
+    for (int tc = 1; tc < T + 1; tc++){
+      q = new ArrayDeque<>();
+      qFire = new ArrayDeque<>();
+      //= start: 입력
+      int result = -1;
+      StringTokenizer st = new StringTokenizer(br.readLine());
+      W = Integer.parseInt(st.nextToken());
+      H = Integer.parseInt(st.nextToken());
+
+      board = new char[H][W];
+      visited = new boolean[H][W];
+      for (int y = 0; y < H; y++){
+        String str = br.readLine();
+        for (int x = 0; x < W; x++){
+          char curChar = str.charAt(x);
+          if (curChar == '@'){
+            q.offer( new Point(x, y, 0) );
+            visited[y][x] = true;
+            board[y][x] = '.';
+            continue;
+          }
+          if (curChar == '*'){
+            qFire.offer( new Point(x, y) );
+          }
+          board[y][x] = curChar;
+        }
+      }
+      // end: 입력
+
+      result = bfs();
+      System.out.println( ( result == -1 ) ? "IMPOSSIBLE" : result );
+    } // for : Test Case;
+
+  }
+
+  static int bfs(){
+    int result = -1;
+
+    OUTER_LOOP:
+    while (!q.isEmpty()){
+      int qSize = q.size();
+      extendFire();
+
+      for (int i = 0; i < qSize; i++){
+        Point cur = q.poll();
+        for (int dir = 0; dir < 4; dir++){
+          int mvX = cur.x + dx[dir];
+          int mvY = cur.y + dy[dir];
+          int mvTime = cur.time + 1;
+
+          //= start: 탈출
+          if ( mvX < 0 || mvY < 0 || mvX >= W || mvY >= H ){
+            result = mvTime;
+            break OUTER_LOOP;
+          } // end
+
+          //= start: 검증
+          if ( visited[mvY][mvX] || board[mvY][mvX] != '.'){
+            continue;
+          } // end: 검증
+
+          visited[mvY][mvX] = true;
+          q.offer( new Point(mvX, mvY, mvTime) );
+        }
+
+      } // while : q
+    }
+
+    return result;
+  }
+
+  static void extendFire(){
+    int qSize = qFire.size();
+    for (int i = 0; i < qSize; i++){
+      Point cur =  qFire.poll();
+
+      for (int dir = 0; dir < 4; dir++){
+        int mvX = cur.x + dx[dir];
+        int mvY = cur.y + dy[dir];
+
+        if (mvX < 0 || mvX >= W || mvY < 0 || mvY >= H){
+          continue;
+        }
+        if (board[mvY][mvX] != '.' || board[mvY][mvX] == '*'){
+          continue;
+        }
+
+        board[mvY][mvX] = '*';
+        qFire.offer( new Point(mvX, mvY) );
+      } // for : dir
+    } // end: qSize
+  }
+
+  static class Point{
+    int x, y, time;
+
+    public Point(int x, int y){
+      this.x = x;
+      this.y = y;
+    }
+    public Point(int x, int y, int time){
+      this.x = x;
+      this.y = y;
+      this.time = time;
+    }
+  }
+}


### PR DESCRIPTION
## 2146_다리만들기
아이디어가 빨리 떠올라서 생각보다 빨리 통과할 수 있었지만, 채점결과 @sarmsoo 선생님의 두배 이상 나와 효율에 큰 문제가 있는 것 같아요. 개선의 여지가 많은 코드라고 생각해서 선생님들의 좋은 피드백 기다리겠습니다.

<br/>

### [ 내 전략 ]
1. 섬 그룹 모두 찾기
2. 두 섬 사이 다리 계산 (= 맨해튼 거리 - 1 )
- | 효율을 위해 섬의 최 외곽간의 비교만 수행했습니다. 이를 위해, Point 클래스에 `isBorder` 불리언 멤버를 두고, 1번 섬 그룹 찾기 수행 중 `mv`가 바다인 경우 `cur`가 바다와 인접한 것으로 판단하여 isBorder에 true를 미리 설정했습니다.


<br/><br/>

![image](https://github.com/SSAFY-potatos/algorithm-potatos/assets/65459616/e50e6003-1b24-4dc0-800a-e9cc76fe4524)


<br/>

## 5427_불

<br/>

최근에 제가 발표했던 [탈출](https://www.acmicpc.net/problem/3055)문제와 워낙 비슷해서 어렵지 않게 풀 수 있었던 것 같습니다.

아래의 두개만 확인하셔도 어떻게 풀었는지 다들 아실 것 같아요!

```java
  static Queue<Point> q = new ArrayDeque<>();
  static Queue<Point> qFire = new ArrayDeque<>();
```

```java
  static class Point{
    int x, y, time;
   ...
   }
```

<br/><br/>

![image](https://github.com/SSAFY-potatos/algorithm-potatos/assets/65459616/1ff7ad28-a31a-437e-9835-74c294b6136f)

<br/><br/>

## 11559_PuyoPuyo

뿌요 그룹을 탐색하고 제거하는 로직은 수월하게 작성했는데, 중력처리에 시행착오를 겪었습니다.
특별한 반례는 없었는지 한번에 통과할 수 있어 기분은 좋았습니다!

### [ 내 전략 ]
 1. 바닥(Y-1)부터 돌면서 방문안한 뿌요(startPuyo) 를 찾는다. 
 
 4. bfs( startPuyo )로 4개이상으로 이뤄진 뿌요그룹을 찾아 반환받고, MatchedPuyos에 추가(addAll)한다.
 
 5. 1~2의 반복 끝에 찾아진, 즉 한 스텝에서 발생한 모든 유효한 뿌요그룹 내 뿌요들(MatchedPuyos)를 제거하고, 연쇄(result)++
    -> 3-ESCAPE) 만일 MatchedPuyos.size()가 0인 경우, 즉 유효한 뿌요가 없는 경우 즉시 종료하고 결과를 출력한다.
 
 6. applyGravity()로 중력을 적용한다.
 
 7. 3-ESCAPE로 탈출할 때 까지 반복한다.
 

### [ 중력 처리 ]
최종적으로 만든 중력처리는 아래처럼 직관적으로 구현했습니다.

각 열에 대해
1. 바닥 바로 위(Y-2)에서부터 올라가며 뿌요를 찾는다. 
  -> 바닥은 내려줄 필요 없잖아요
2. 뿌요 발견 시 빈공간이 있는 한 계속 내려준다.
4. 이를 반복한다. 


### [ 중력 처리 시행착오 ]
처음에 효율적인 중력처리 코드를 만들려다가 겪은 시행착오입니다.


처음에 보드의 열 길이만큼의 배열을 가진 `cntPuyoByColumn`이라는 변수를 선언하고, 
보드 상태를 입력받으며, 뿌요칸인 경우 `cntPuyoByColumn[ x ]++`를 하여 열별 뿌요 수를 미리 카운트해줬습니다.

이후, 뿌요그룹 확인(bfs) 및 일괄 제거 후 중력처리를 수행할 때,
cntPuyoByColumn[ x ] 에 뿌요수가 기록된 열만 바닥에 빈공간이 없을 때 까지, 아래로 한칸씩 땡겨오면 될 것으로 생각했고 이처럼 코드를 짰는데,

바닥의 뿌요그룹이 아닌 중간의 뿌요그룹이 제거되는 경우엔 바닥 빈공간만 채워준다고 되는것이 아니란걸 깨닫고 지금 코드처럼 직관적인 방식으로 바꿨습니다.

<br/><br/>

![image](https://github.com/SSAFY-potatos/algorithm-potatos/assets/65459616/e2485972-acf3-4915-950e-d78ea3b9e452)

<br/><br/>



